### PR TITLE
Travis CIのテストとビルドに要する時間を短くする

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ os:
 dist: bionic
 go:
   - 1.12.x
-  - master
 env: GO111MODULE=on
 script: go test ./pkg/...
 
@@ -20,21 +19,8 @@ jobs:
       before_script: scripts/install_prerequisites_linux.sh
       script: make
     - stage: build
-      os: linux
-      dist: bionic
-      go: master
-      env: GO111MODULE=on
-      before_script: scripts/install_prerequisites_linux.sh
-      script: make
-    - stage: build
       os: osx
       go: 1.12.x
-      env: GO111MODULE=on
-      before_script: scripts/install_prerequisites_osx.sh
-      script: make
-    - stage: build
-      os: osx
-      go: master
       env: GO111MODULE=on
       before_script: scripts/install_prerequisites_osx.sh
       script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ os:
   - linux
   - osx
 
+# Ubuntu 18.04を使用する
+dist: bionic
+
 go:
   - 1.12.x
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,40 @@
 language: go
-
 os:
   - linux
   - osx
-
 # Ubuntu 18.04を使用する
 dist: bionic
-
 go:
   - 1.12.x
   - master
+env: GO111MODULE=on
+script: go test ./pkg/...
 
-env:
-  - GO111MODULE=on
-
-before_install:
-  - echo $TRAVIS_OS_NAME
-  # Linux
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get -qq update           ; fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then sudo apt-get install libgtk-3-dev ; fi
-  # macOS
-  - if [ "$TRAVIS_OS_NAME" == "osx"   ]; then brew update                       ; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx"   ]; then brew install gtk+3                ; fi
-  - if [ "$TRAVIS_OS_NAME" == "osx"   ]; then ulimit -n 8192                    ; fi
-
-script:
-  - go test ./...
+jobs:
+  include:
+    - stage: build
+      os: linux
+      dist: bionic
+      go: 1.12.x
+      env: GO111MODULE=on
+      before_script: scripts/install_prerequisites_linux.sh
+      script: make
+    - stage: build
+      os: linux
+      dist: bionic
+      go: master
+      env: GO111MODULE=on
+      before_script: scripts/install_prerequisites_linux.sh
+      script: make
+    - stage: build
+      os: osx
+      go: 1.12.x
+      env: GO111MODULE=on
+      before_script: scripts/install_prerequisites_osx.sh
+      script: make
+    - stage: build
+      os: osx
+      go: master
+      env: GO111MODULE=on
+      before_script: scripts/install_prerequisites_osx.sh
+      script: make

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: all clean
+
+all:
+	$(MAKE) -C cmd
+
+clean:
+	$(MAKE) -C cmd clean

--- a/cmd/GoBCDiceAPI/Makefile
+++ b/cmd/GoBCDiceAPI/Makefile
@@ -1,0 +1,9 @@
+TARGET := GoBCDiceAPI
+
+$(TARGET):
+	go build
+
+.PHONY: clean
+
+clean:
+	$(RM) $(TARGET)

--- a/cmd/GoBCDiceCUI/Makefile
+++ b/cmd/GoBCDiceCUI/Makefile
@@ -1,0 +1,9 @@
+TARGET := GoBCDiceCUI
+
+$(TARGET):
+	go build
+
+.PHONY: clean
+
+clean:
+	$(RM) $(TARGET)

--- a/cmd/GoBCDiceGUI/Makefile
+++ b/cmd/GoBCDiceGUI/Makefile
@@ -1,0 +1,9 @@
+TARGET := GoBCDiceGUI
+
+$(TARGET):
+	go build
+
+.PHONY: clean
+
+clean:
+	$(RM) $(TARGET)

--- a/cmd/GoBCDiceREPL/Makefile
+++ b/cmd/GoBCDiceREPL/Makefile
@@ -1,0 +1,9 @@
+TARGET := GoBCDiceREPL
+
+$(TARGET):
+	go build
+
+.PHONY: clean
+
+clean:
+	$(RM) $(TARGET)

--- a/cmd/Makefile
+++ b/cmd/Makefile
@@ -1,0 +1,13 @@
+.PHONY: all clean
+
+all:
+	$(MAKE) -C GoBCDiceAPI
+	$(MAKE) -C GoBCDiceCUI
+	$(MAKE) -C GoBCDiceGUI
+	$(MAKE) -C GoBCDiceREPL
+
+clean:
+	$(MAKE) -C GoBCDiceAPI clean
+	$(MAKE) -C GoBCDiceCUI clean
+	$(MAKE) -C GoBCDiceGUI clean
+	$(MAKE) -C GoBCDiceREPL clean

--- a/scripts/install_prerequisites_linux.sh
+++ b/scripts/install_prerequisites_linux.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+sudo apt-get -qq update
+sudo apt-get install libgtk-3-dev

--- a/scripts/install_prerequisites_osx.sh
+++ b/scripts/install_prerequisites_osx.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+brew update
+brew install gtk+3


### PR DESCRIPTION
Travis CIのテストとビルドに要する時間を短くしました。

現段階におけるCIの主な用途は新しい環境でテストが通るか確認することですが、ライブラリ部のテストでは必要ない、GUIに必要なライブラリのインストールで非常に長い時間がかかっていました。そこで、テストとビルドの2ステージに分け、GUIに必要なライブラリはビルドの段階で初めてインストールするように変更することで、テストがコンテナ起動後1分以内に終わるようにしました。

また、Go masterの環境で特にテスト、ビルド完了まで時間がかかっていたため、Go 1.12.xのみをテスト、ビルド環境にしました。Goの仕様は安定していて、リリース版のみでも問題ないと判断しました。