### PR TITLE
go-accで正確なカバレッジを取得する

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,6 +11,7 @@ before_test:
   - SET GO111MODULE=off
   - go get -u github.com/ory/go-acc
   - SET GO111MODULE=on
+  - go get ./pkg/...
 
 test_script:
   - C:\gopath\bin\go-acc ./pkg/... -- -race

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -7,8 +7,13 @@ environment:
 
 stack: go 1.12.3
 
+before_test:
+  - SET GO111MODULE=off
+  - go get -u github.com/ory/go-acc
+  - SET GO111MODULE=on
+
 test_script:
-  - go test -race -coverprofile=coverage.txt -covermode=atomic ./pkg/...
+  - C:\gopath\bin\go-acc ./pkg/... -- -race
 
 after_test:
   - ps: |


### PR DESCRIPTION
[go-acc](https://github.com/ory/go-acc)というツールを利用して正確なカバレッジを取得するようにしました。

# 問題

通常の `go test -cover` を使用したカバレッジ取得では、構文解析時に使われる構造体に関連したコードが実行されていないことになっているなど、結果が正しくありませんでした：

https://codecov.io/gh/raa0121/GoBCDice/tree/243ba3a09342ca26fc6ed7025fdb4710d9ca02de/pkg/core/ast

全体のカバレッジは59.76%となっていました：

https://codecov.io/gh/raa0121/GoBCDice/tree/243ba3a09342ca26fc6ed7025fdb4710d9ca02de

# 原因

「[How to get accurate code coverage in Golang (Go)](https://www.ory.sh/golang-go-code-coverage-accurate)」という記事によると、原因は `go test -cover` がテスト中のパッケージのみを対象としてカバレッジを記録することだそうです。

# 対策

AppVeyorでのテスト時に[go-acc](https://github.com/ory/go-acc)というツールを使用するようにしました。このツールは、カバレッジ計算の対象をテスト中のパッケージだけでなく全パッケージに広げることによって、正確なカバレッジを算出します。

# 対策後の結果

`go test -cover` で記録されていなかった部分のコードもカバーされるようになり、期待どおりのカバレッジが算出されました。例えば、前述の構文解析時に使われる構造体に関連したコードのカバレッジは以下のように上昇しました。

https://codecov.io/gh/raa0121/GoBCDice/tree/234b34522a764ccc014b0e7ebf113692645b19f2/pkg/core

そのため、全体のカバレッジも74.53%と、15%ほど高くなりました。

https://codecov.io/gh/raa0121/GoBCDice/tree/234b34522a764ccc014b0e7ebf113692645b19f2