### PR TITLE
シークレットロールを実装する

### DIFF
--- a/pkg/bcdice/bcdice.go
+++ b/pkg/bcdice/bcdice.go
@@ -1,15 +1,17 @@
 package bcdice
 
 import (
+	"regexp"
+
 	"github.com/raa0121/GoBCDice/pkg/core/ast"
 	"github.com/raa0121/GoBCDice/pkg/core/command"
 	"github.com/raa0121/GoBCDice/pkg/core/dice/feeder"
 	"github.com/raa0121/GoBCDice/pkg/core/dice/roller"
 	"github.com/raa0121/GoBCDice/pkg/core/evaluator"
 	"github.com/raa0121/GoBCDice/pkg/core/parser"
+	"github.com/raa0121/GoBCDice/pkg/core/util"
 	"github.com/raa0121/GoBCDice/pkg/dicebot"
 	dicebotlist "github.com/raa0121/GoBCDice/pkg/dicebot/list"
-	"regexp"
 )
 
 // BCDiceの全体動作を統括する構造体。
@@ -59,7 +61,7 @@ var commandFirstPartRe = regexp.MustCompile(`\A([^\s]*)(\s.*)?`)
 
 // ExecuteCommand は指定されたコマンドを実行する。
 func (b *BCDice) ExecuteCommand(input string) (*command.Result, error) {
-	command, isSecret := checkIfInputMayBeASecretRoll(input)
+	command, isSecret := util.CheckIfInputMayBeASecretRoll(input)
 
 	separated := commandFirstPartRe.FindStringSubmatch(command)
 	firstPart := separated[1]
@@ -114,24 +116,4 @@ func (b *BCDice) ExecuteBasicCommand(c string) (*command.Result, error) {
 	ev := evaluator.NewEvaluator(b.diceRoller, env)
 
 	return command.Execute(node.(ast.Node), b.DiceBot.GameID(), ev)
-}
-
-// checkIfInputMayBeASecretRoll は input がシークレットロールの可能性があるか確認する。
-//
-// 返り値:
-// シークレットロールのマークを除去した入力文字列,
-// シークレットロールの可能性があるか（true/false）
-func checkIfInputMayBeASecretRoll(input string) (string, bool) {
-	if len(input) < 1 {
-		return "", false
-	}
-
-	inputRunes := []rune(input)
-
-	switch inputRunes[0] {
-	case 'S', 's':
-		return string(inputRunes[1:len(inputRunes)]), true
-	default:
-		return input, false
-	}
 }

--- a/pkg/core/command/result.go
+++ b/pkg/core/command/result.go
@@ -43,6 +43,8 @@ type Result struct {
 	RolledDice []dice.Die
 	// 成功判定の結果
 	SuccessCheckResult SuccessCheckResultType
+	// シークレットロールかどうか
+	IsSecret bool
 }
 
 // JoinedMessageParts は、メッセージの部分を結合したものを返す。

--- a/pkg/core/util/secret_roll.go
+++ b/pkg/core/util/secret_roll.go
@@ -1,0 +1,21 @@
+package util
+
+// CheckIfInputMayBeASecretRoll は input がシークレットロールの可能性があるか確認する。
+//
+// 返り値:
+// シークレットロールのマークを除去した入力文字列,
+// シークレットロールの可能性があるか（true/false）
+func CheckIfInputMayBeASecretRoll(input string) (string, bool) {
+	if len(input) < 1 {
+		return "", false
+	}
+
+	inputRunes := []rune(input)
+
+	switch inputRunes[0] {
+	case 'S', 's':
+		return string(inputRunes[1:len(inputRunes)]), true
+	default:
+		return input, false
+	}
+}

--- a/pkg/dicebot/gamesystem/basic/basic_test.go
+++ b/pkg/dicebot/gamesystem/basic/basic_test.go
@@ -18,6 +18,7 @@ func TestDiceBot(t *testing.T) {
 		"u_roll_expr.txt",
 		"u_roll_comp.txt",
 		"choice.txt",
+		"secret_roll.txt",
 	}
 
 	testDataFiles := joinWithTestData(testDataFileBaseNames)

--- a/pkg/dicebot/gamesystem/basic/testdata/secret_roll.txt
+++ b/pkg/dicebot/gamesystem/basic/testdata/secret_roll.txt
@@ -1,0 +1,35 @@
+input:
+S2d6
+output:
+DiceBot : (2D6) ＞ 5[4,1] ＞ 5###secret dice###
+rand:4/6,1/6
+============================
+input:
+s2d6
+output:
+DiceBot : (2D6) ＞ 5[4,1] ＞ 5###secret dice###
+rand:4/6,1/6
+============================
+input:
+S1U6[3]
+output:
+DiceBot : (1U6[3]) ＞ 5[3,2] ＞ 5/5 (最大/合計)###secret dice###
+rand:3/6,2/6
+============================
+input:
+S3B6>=4
+output:
+DiceBot : (3B6>=4) ＞ 5,2,4 ＞ 成功数2###secret dice###
+rand:5/6,2/6,4/6
+============================
+input:
+Schoice[abc2,def3]
+output:
+DiceBot : (CHOICE[abc2,def3]) ＞ def3###secret dice###
+rand:2/2
+============================
+input:
+S2R6[3]
+output:
+DiceBot : (2R6[3]) ＞ 3,2 + 1###secret dice###
+rand:3/6,2/6,1/6

--- a/pkg/dicebot/testing/testing.go
+++ b/pkg/dicebot/testing/testing.go
@@ -57,7 +57,13 @@ func Run(gameID string, t *testing.T, testDataFiles ...string) {
 			}
 
 			expected := test.Output
-			actual := result.Message()
+
+			var actual string
+			if result.IsSecret {
+				actual = fmt.Sprintf("%s###secret dice###", result.Message())
+			} else {
+				actual = result.Message()
+			}
 
 			if actual != expected {
 				t.Errorf("got: %q, want: %q", actual, expected)


### PR DESCRIPTION
（上方無限ロールの続きですので、#38 のマージ後の確認をお願いします）

シークレットロール（`S`）を実装しました。Ruby版と同様に、`S` または `s` が先頭についていたとき、その部分を除いて構文解析を行います（そのため、これまでの構文解析処理は変更していません）。結果の構造体に追加した `IsSecret` というフラグを呼び出し側が管理する形です。

そのままだと特にREPLで変化が分かりにくいため、REPLではシークレットロールかどうかの表示を行うようにしました。

<img width="556" alt="GoBCDice-secret_roll" src="https://user-images.githubusercontent.com/2551173/67030431-5f48ef00-f14a-11e9-9c2d-064964be883b.png">
