### PR TITLE
ゲームシステム専用ダイスボットの基本情報定義など

### DIFF
--- a/pkg/core/command/execute_b_roll_comp.go
+++ b/pkg/core/command/execute_b_roll_comp.go
@@ -36,9 +36,9 @@ func executeBRollComp(
 	result.RolledDice = evaluator.RolledDice()
 
 	// 結果のメッセージを作る
-	result.appendMessagePart(notation.Parenthesize(infixNotation))
-	result.appendMessagePart(resultObj.Values.JoinedElements(","))
-	result.appendMessagePart("成功数" + resultObj.NumOfSuccesses.Inspect())
+	result.AppendMessagePart(notation.Parenthesize(infixNotation))
+	result.AppendMessagePart(resultObj.Values.JoinedElements(","))
+	result.AppendMessagePart("成功数" + resultObj.NumOfSuccesses.Inspect())
 
 	return result, nil
 }

--- a/pkg/core/command/execute_b_roll_list.go
+++ b/pkg/core/command/execute_b_roll_list.go
@@ -34,8 +34,8 @@ func executeBRollList(
 	result.RolledDice = evaluator.RolledDice()
 
 	// 結果のメッセージを作る
-	result.appendMessagePart(notation.Parenthesize(infixNotation))
-	result.appendMessagePart(arrayObj.JoinedElements(","))
+	result.AppendMessagePart(notation.Parenthesize(infixNotation))
+	result.AppendMessagePart(arrayObj.JoinedElements(","))
 
 	return result, nil
 }

--- a/pkg/core/command/execute_calc.go
+++ b/pkg/core/command/execute_calc.go
@@ -29,9 +29,9 @@ func executeCalc(
 	}
 
 	// 結果のメッセージを作る
-	result.appendMessagePart(infixNotation)
-	result.appendMessagePart("計算結果")
-	result.appendMessagePart(obj.Inspect())
+	result.AppendMessagePart(infixNotation)
+	result.AppendMessagePart("計算結果")
+	result.AppendMessagePart(obj.Inspect())
 
 	return result, nil
 }

--- a/pkg/core/command/execute_choice.go
+++ b/pkg/core/command/execute_choice.go
@@ -33,8 +33,8 @@ func executeChoice(
 	result.RolledDice = evaluator.RolledDice()
 
 	// 結果のメッセージを作る
-	result.appendMessagePart(notation.Parenthesize(infixNotation))
-	result.appendMessagePart(resultObj.Value)
+	result.AppendMessagePart(notation.Parenthesize(infixNotation))
+	result.AppendMessagePart(resultObj.Value)
 
 	return result, nil
 }

--- a/pkg/core/command/execute_d_roll_comp.go
+++ b/pkg/core/command/execute_d_roll_comp.go
@@ -66,10 +66,10 @@ func executeDRollComp(
 		successCheckResultMessage = "失敗"
 	}
 
-	result.appendMessagePart(notation.Parenthesize(infixNotation1))
-	result.appendMessagePart(infixNotation2)
-	result.appendMessagePart(leftObj.Inspect())
-	result.appendMessagePart(successCheckResultMessage)
+	result.AppendMessagePart(notation.Parenthesize(infixNotation1))
+	result.AppendMessagePart(infixNotation2)
+	result.AppendMessagePart(leftObj.Inspect())
+	result.AppendMessagePart(successCheckResultMessage)
 
 	return result, nil
 }

--- a/pkg/core/command/execute_d_roll_expr.go
+++ b/pkg/core/command/execute_d_roll_expr.go
@@ -37,9 +37,9 @@ func executeDRollExpr(
 	result.RolledDice = evaluator.RolledDice()
 
 	// 結果のメッセージを作る
-	result.appendMessagePart(notation.Parenthesize(infixNotation1))
-	result.appendMessagePart(infixNotation2)
-	result.appendMessagePart(obj.Inspect())
+	result.AppendMessagePart(notation.Parenthesize(infixNotation1))
+	result.AppendMessagePart(infixNotation2)
+	result.AppendMessagePart(obj.Inspect())
 
 	return result, nil
 }

--- a/pkg/core/command/execute_r_roll_comp.go
+++ b/pkg/core/command/execute_r_roll_comp.go
@@ -37,13 +37,13 @@ func executeRRollComp(
 		return nil, infixNotationErr
 	}
 
-	result.appendMessagePart(notation.Parenthesize(infixNotation))
+	result.AppendMessagePart(notation.Parenthesize(infixNotation))
 
 	// 振り足しの閾値を確認する
 	checkRerollThresholdErr :=
 		evaluator.CheckRRollThreshold(compareNode.Left().(*ast.RRollList))
 	if checkRerollThresholdErr != nil {
-		result.appendMessagePart(checkRerollThresholdErr.Error())
+		result.AppendMessagePart(checkRerollThresholdErr.Error())
 		return result, nil
 	}
 
@@ -57,8 +57,8 @@ func executeRRollComp(
 	result.RolledDice = evaluator.RolledDice()
 
 	// 結果のメッセージを作る
-	result.appendMessagePart(formatRRollValues(resultObj.ValueGroups))
-	result.appendMessagePart("成功数" + resultObj.NumOfSuccesses.Inspect())
+	result.AppendMessagePart(formatRRollValues(resultObj.ValueGroups))
+	result.AppendMessagePart("成功数" + resultObj.NumOfSuccesses.Inspect())
 
 	return result, nil
 }

--- a/pkg/core/command/execute_r_roll_list.go
+++ b/pkg/core/command/execute_r_roll_list.go
@@ -25,12 +25,12 @@ func executeRRollList(
 		return nil, evalVarArgsErr
 	}
 
-	result.appendMessagePart(notation.Parenthesize(infixNotation))
+	result.AppendMessagePart(notation.Parenthesize(infixNotation))
 
 	// 振り足しの閾値を確認する
 	checkRerollThresholdErr := evaluator.CheckRRollThreshold(node)
 	if checkRerollThresholdErr != nil {
-		result.appendMessagePart(checkRerollThresholdErr.Error())
+		result.AppendMessagePart(checkRerollThresholdErr.Error())
 		return result, nil
 	}
 
@@ -44,7 +44,7 @@ func executeRRollList(
 	result.RolledDice = evaluator.RolledDice()
 
 	// 結果のメッセージを作る
-	result.appendMessagePart(formatRRollValues(valueGroups))
+	result.AppendMessagePart(formatRRollValues(valueGroups))
 
 	return result, nil
 }

--- a/pkg/core/command/execute_u_roll_comp.go
+++ b/pkg/core/command/execute_u_roll_comp.go
@@ -31,14 +31,14 @@ func executeURollComp(
 		return nil, infixNotationErr
 	}
 
-	result.appendMessagePart(notation.Parenthesize(infixNotation))
+	result.AppendMessagePart(notation.Parenthesize(infixNotation))
 
 	// 振り足しの閾値を確認する
 	checkRerollThresholdErr := evaluator.CheckURollThreshold(
 		compareNode.Left().(*ast.URollExpr).URollList,
 	)
 	if checkRerollThresholdErr != nil {
-		result.appendMessagePart(checkRerollThresholdErr.Error())
+		result.AppendMessagePart(checkRerollThresholdErr.Error())
 		return result, nil
 	}
 
@@ -52,10 +52,10 @@ func executeURollComp(
 	result.RolledDice = evaluator.RolledDice()
 
 	// 結果のメッセージを作る
-	result.appendMessagePart(
+	result.AppendMessagePart(
 		formatURollExprValueGroupsAndModifier(resultObj.RollResult),
 	)
-	result.appendMessagePart("成功数" + resultObj.NumOfSuccesses.Inspect())
+	result.AppendMessagePart("成功数" + resultObj.NumOfSuccesses.Inspect())
 
 	return result, nil
 }

--- a/pkg/core/command/execute_u_roll_expr.go
+++ b/pkg/core/command/execute_u_roll_expr.go
@@ -27,12 +27,12 @@ func executeURollExpr(
 		return nil, evalVarArgsErr
 	}
 
-	result.appendMessagePart(notation.Parenthesize(infixNotation))
+	result.AppendMessagePart(notation.Parenthesize(infixNotation))
 
 	// 振り足しの閾値を確認する
 	checkRerollThresholdErr := evaluator.CheckURollThreshold(node.URollList)
 	if checkRerollThresholdErr != nil {
-		result.appendMessagePart(checkRerollThresholdErr.Error())
+		result.AppendMessagePart(checkRerollThresholdErr.Error())
 		return result, nil
 	}
 
@@ -45,8 +45,8 @@ func executeURollExpr(
 	uRollExprResult := obj.(*object.URollExprResult)
 	result.RolledDice = evaluator.RolledDice()
 
-	result.appendMessagePart(formatURollExprValueGroupsAndModifier(uRollExprResult))
-	result.appendMessagePart(fmt.Sprintf(
+	result.AppendMessagePart(formatURollExprValueGroupsAndModifier(uRollExprResult))
+	result.AppendMessagePart(fmt.Sprintf(
 		"%d/%d (最大/合計)",
 		uRollExprResult.MaxValue().Value,
 		uRollExprResult.SumOfValues().Value,

--- a/pkg/core/command/result.go
+++ b/pkg/core/command/result.go
@@ -57,7 +57,7 @@ func (r *Result) Message() string {
 	return r.GameID + " : " + r.JoinedMessageParts()
 }
 
-// appendMessagePart はメッセージの部分を追加する。
-func (r *Result) appendMessagePart(message string) {
+// AppendMessagePart はメッセージの部分を追加する。
+func (r *Result) AppendMessagePart(message string) {
 	r.MessageParts = append(r.MessageParts, message)
 }

--- a/pkg/dicebot/dicebot.go
+++ b/pkg/dicebot/dicebot.go
@@ -4,6 +4,8 @@
 package dicebot
 
 import (
+	"fmt"
+
 	"github.com/raa0121/GoBCDice/pkg/core/command"
 	"github.com/raa0121/GoBCDice/pkg/core/evaluator"
 )
@@ -21,4 +23,48 @@ type DiceBot interface {
 	Usage() string
 	// ExecuteCommand は指定されたコマンドを実行する。
 	ExecuteCommand(command string, ev *evaluator.Evaluator) (*command.Result, error)
+}
+
+// DiceBotBasicInfo はダイスボットの基本情報を表す構造体。
+type DiceBotBasicInfo struct {
+	// GameID はゲーム識別子。
+	GameID string
+	// GameName はゲームシステム名。
+	GameName string
+	// Usage はダイスボットの使用法の説明。
+	Usage string
+}
+
+// DiceBotImpl はダイスボットの実装のベースとなる構造体。
+type DiceBotImpl struct {
+	// BasicInfo はダイスボットの基本情報。
+	BasicInfo *DiceBotBasicInfo
+}
+
+// DiceBotImpl がDiceBotを実装していることを確認する。
+var _ DiceBot = (*DiceBotImpl)(nil)
+
+// GameID はゲーム識別子を返す。
+func (d *DiceBotImpl) GameID() string {
+	return d.BasicInfo.GameID
+}
+
+// GameName はゲームシステム名を返す。
+func (d *DiceBotImpl) GameName() string {
+	return d.BasicInfo.GameName
+}
+
+// Usage はダイスボットの使用法の説明を返す。
+func (d *DiceBotImpl) Usage() string {
+	return d.BasicInfo.Usage
+}
+
+// ExecuteCommand は指定されたコマンドを実行する。
+//
+// 基本のダイスボットには特別なコマンドが存在しないため、必ずエラーを返す。
+func (b *DiceBotImpl) ExecuteCommand(
+	_ string,
+	_ *evaluator.Evaluator,
+) (*command.Result, error) {
+	return nil, fmt.Errorf("no game-system-specific command")
 }

--- a/pkg/dicebot/gamesystem/basic/basic.go
+++ b/pkg/dicebot/gamesystem/basic/basic.go
@@ -4,39 +4,14 @@
 package basic
 
 import (
-	"fmt"
-	"github.com/raa0121/GoBCDice/pkg/core/command"
-	"github.com/raa0121/GoBCDice/pkg/core/evaluator"
 	"github.com/raa0121/GoBCDice/pkg/dicebot"
 )
 
-const (
-	// 基本的なダイスボットのゲーム識別子
-	GAME_ID = "DiceBot"
-)
-
-// 基本的なダイスボット。
-type Basic struct {
-}
-
-// New は新しいダイスボットを構築する。
-func New() dicebot.DiceBot {
-	return &Basic{}
-}
-
-// GameID はゲーム識別子を返す。
-func (b *Basic) GameID() string {
-	return "DiceBot"
-}
-
-// GameName はゲームシステム名を返す。
-func (b *Basic) GameName() string {
-	return "ダイスボット (指定無し)"
-}
-
-// Usage はダイスボットの使用法の説明を返す。
-func (b *Basic) Usage() string {
-	return `【ダイスボット】チャットにダイス用の文字を入力するとダイスロールが可能
+// basicInfo はダイスボットの基本情報。
+var basicInfo = dicebot.DiceBotBasicInfo{
+	GameID:   "DiceBot",
+	GameName: "ダイスボット (指定無し)",
+	Usage: `【ダイスボット】チャットにダイス用の文字を入力するとダイスロールが可能
 入力例）２ｄ６＋１　攻撃！
 出力例）2d6+1　攻撃！
 　　　　  diceBot: (2d6) → 7
@@ -52,15 +27,24 @@ func (b *Basic) Usage() string {
 　choice[a,b,c]：列挙した要素から一つを選択表示。ランダム攻撃対象決定などに
 　S3d6 ： 各コマンドの先頭に「S」を付けると他人結果の見えないシークレットロール
 　3d6/2 ： ダイス出目を割り算（切り捨て）。切り上げは /2U、四捨五入は /2R。
-　D66 ： D66ダイス。順序はゲームに依存。D66N：そのまま、D66S：昇順。`
+　D66 ： D66ダイス。順序はゲームに依存。D66N：そのまま、D66S：昇順。`,
 }
 
-// ExecuteCommand は指定されたコマンドを実行する。
-//
-// 基本のダイスボットには特別なコマンドが存在しないため、必ずエラーを返す。
-func (b *Basic) ExecuteCommand(
-	_ string,
-	_ *evaluator.Evaluator,
-) (*command.Result, error) {
-	return nil, fmt.Errorf("no game-system-specific command")
+// BasicInfo はダイスボットの基本情報を返す。
+func BasicInfo() *dicebot.DiceBotBasicInfo {
+	return &basicInfo
+}
+
+// 基本的なダイスボット。
+type Basic struct {
+	dicebot.DiceBotImpl
+}
+
+// New は新しいダイスボットを構築する。
+func New() dicebot.DiceBot {
+	return &Basic{
+		DiceBotImpl: dicebot.DiceBotImpl{
+			BasicInfo: BasicInfo(),
+		},
+	}
 }

--- a/pkg/dicebot/gamesystem/basic/basic_test.go
+++ b/pkg/dicebot/gamesystem/basic/basic_test.go
@@ -1,9 +1,11 @@
 package basic_test
 
 import (
-	dicebottesting "github.com/raa0121/GoBCDice/pkg/dicebot/testing"
 	"path/filepath"
 	"testing"
+
+	"github.com/raa0121/GoBCDice/pkg/dicebot/gamesystem/basic"
+	dicebottesting "github.com/raa0121/GoBCDice/pkg/dicebot/testing"
 )
 
 func TestDiceBot(t *testing.T) {
@@ -23,6 +25,30 @@ func TestDiceBot(t *testing.T) {
 
 	testDataFiles := joinWithTestData(testDataFileBaseNames)
 	dicebottesting.Run("DiceBot", t, testDataFiles...)
+}
+
+func TestBasic_GameID(t *testing.T) {
+	expected := "DiceBot"
+	actual := basic.New().GameID()
+
+	if actual != expected {
+		t.Fatalf("got: %q, want: %q", actual, expected)
+	}
+}
+
+func TestBasic_GameName(t *testing.T) {
+	expected := "ダイスボット (指定無し)"
+	actual := basic.New().GameName()
+
+	if actual != expected {
+		t.Fatalf("got: %q, want: %q", actual, expected)
+	}
+}
+
+func TestBasic_Usage(t *testing.T) {
+	if len(basic.New().Usage()) <= 0 {
+		t.Fatal("Usage() が空文字列")
+	}
 }
 
 func joinWithTestData(basenames []string) []string {

--- a/pkg/dicebot/gamesystem/basic/basic_test.go
+++ b/pkg/dicebot/gamesystem/basic/basic_test.go
@@ -1,7 +1,6 @@
 package basic_test
 
 import (
-	"path/filepath"
 	"testing"
 
 	"github.com/raa0121/GoBCDice/pkg/dicebot/gamesystem/basic"
@@ -23,7 +22,7 @@ func TestDiceBot(t *testing.T) {
 		"secret_roll.txt",
 	}
 
-	testDataFiles := joinWithTestData(testDataFileBaseNames)
+	testDataFiles := dicebottesting.JoinWithTestData(testDataFileBaseNames)
 	dicebottesting.Run("DiceBot", t, testDataFiles...)
 }
 
@@ -49,14 +48,4 @@ func TestBasic_Usage(t *testing.T) {
 	if len(basic.New().Usage()) <= 0 {
 		t.Fatal("Usage() が空文字列")
 	}
-}
-
-func joinWithTestData(basenames []string) []string {
-	files := make([]string, 0, len(basenames))
-
-	for _, b := range basenames {
-		files = append(files, filepath.Join("testdata", b))
-	}
-
-	return files
 }

--- a/pkg/dicebot/list/list.go
+++ b/pkg/dicebot/list/list.go
@@ -15,7 +15,7 @@ import (
 // Find は指定された識別子を持つゲームシステムのダイスボットのコンストラクタを返す。
 // ゲームシステムが見つからなかった場合はエラーを返す。
 func Find(gameID string) (dicebot.DiceBotConstructor, error) {
-	if gameID == basic.GAME_ID {
+	if gameID == basic.BasicInfo().GameID {
 		return basic.New, nil
 	}
 
@@ -42,7 +42,7 @@ func AvailableGameIDs(includeBasicDiceBot bool) []string {
 	}
 
 	gameIDsWithBasicDiceBot := make([]string, 1, len(gameIDs)+1)
-	gameIDsWithBasicDiceBot[0] = basic.GAME_ID
+	gameIDsWithBasicDiceBot[0] = basic.BasicInfo().GameID
 	gameIDsWithBasicDiceBot = append(gameIDsWithBasicDiceBot, gameIDs...)
 
 	return gameIDsWithBasicDiceBot

--- a/pkg/dicebot/testing/testing.go
+++ b/pkg/dicebot/testing/testing.go
@@ -5,10 +5,12 @@ package testing
 
 import (
 	"fmt"
+	"path/filepath"
+	"testing"
+
 	"github.com/raa0121/GoBCDice/pkg/bcdice"
 	"github.com/raa0121/GoBCDice/pkg/core/dice"
 	"github.com/raa0121/GoBCDice/pkg/core/dice/feeder"
-	"testing"
 )
 
 // Run はダイスボットのテストを実行する。
@@ -74,4 +76,15 @@ func Run(gameID string, t *testing.T, testDataFiles ...string) {
 			}
 		})
 	}
+}
+
+// JoinWithTestData はbasenamesの各要素の先頭に "testdata/" を追加したスライスを返す。
+func JoinWithTestData(basenames []string) []string {
+	files := make([]string, 0, len(basenames))
+
+	for _, b := range basenames {
+		files = append(files, filepath.Join("testdata", b))
+	}
+
+	return files
 }


### PR DESCRIPTION
基本のダイスロールが落ち着いたので、ゲームシステム専用ダイスボットを作れるように、基本情報定義の仕組みを整えました。その他、共通で使えそうな関数（dicebot/testing.JoinWithTestData、core/command.Result#AppendMessagePart）をpublicにしました。